### PR TITLE
Add GPT-4o mini support

### DIFF
--- a/package.json
+++ b/package.json
@@ -459,6 +459,7 @@
             "gpt-4",
             "gpt-4-32k",
             "gpt-4o",
+            "gpt-4o-mini",
             "gpt-3.5-turbo",
             "gpt-3.5-turbo-16k",
           ],
@@ -470,6 +471,7 @@
             "gpt-4",
             "gpt-4-32k",
             "gpt-4o",
+            "gpt-4o-mini",
             "gpt-3.5-turbo",
             "gpt-3.5-turbo-16k",
           ],
@@ -478,6 +480,7 @@
             "GPT-4, 2x longer inputs than GPT-3",
             "GPT-4-32k, This is 4x GPT-4 max length and 8x GPT-3 max length.",
             "GPT-4o, newest high speed and cheaper GPT-4 series model",
+            "GPT-4o mini, successor of GPT-3.5 Turbo, which is cheaper, more capable, and just fast.",
             "GPT-3.5-TURBO is optimized for chat at 1/10th the cost of `text-davinci-003`.",
             "GPT-3.5-TURBO-16K is the same as `gpt-3.5-turbo` but with 16k tokens."
           ]

--- a/src/renderer/components/ModelSelect.tsx
+++ b/src/renderer/components/ModelSelect.tsx
@@ -65,12 +65,13 @@ export default function ModelSelect({
   const convertMarkdownToComponent = useConvertMarkdownToComponent(vscode);
 
   const hasOpenAIModels = useMemo(() => {
-    // check if the model list has at least one of: gpt-4, gpt-4-turbo, gpt-4o, gpt-3.5-turbo
+    // check if the model list has at least one of: gpt-4, gpt-4-turbo, gpt-4o, gpt-4o-mini, gpt-3.5-turbo
     return models.some(
       (model) =>
         model.id === "gpt-4" ||
         model.id === "gpt-4-turbo" ||
         model.id === "gpt-4o" ||
+        model.id === "gpt-4o-mini" ||
         model.id === "gpt-3.5-turbo"
     );
   }, [models]);
@@ -792,6 +793,40 @@ export default function ModelSelect({
                           <>
                             , Completion:{" "}
                             <code>{MODEL_TOKEN_LIMITS.get(gpt4o.id)?.max}</code>
+                          </>
+                        )}
+                      </p>
+                    </button>
+                  );
+                })()}
+              {models &&
+                (() => {
+                  const gpt4omini = models.find((model) => model.id === "gpt-4o-mini");
+
+                  if (!gpt4omini) {
+                    return null;
+                  }
+
+                  return (
+                    <button
+                      className="flex flex-col gap-2 items-start justify-start p-2 w-full hover:bg-menu-selection"
+                      onClick={() => {
+                        setModel(gpt4omini);
+                        if (showParentMenu) {
+                          showParentMenu(false);
+                        }
+                      }}
+                    >
+                      <span>
+                        <code>gpt-4o-mini</code>
+                      </span>
+                      <p>
+                        Quality: ⭐⭐⬜, Speed: ⚡⚡⚡, Cost: 💸⬜⬜, Context:{" "}
+                        <code>{MODEL_TOKEN_LIMITS.get(gpt4omini.id)?.context}</code>
+                        {MODEL_TOKEN_LIMITS.get(gpt4omini.id)?.max && (
+                          <>
+                            , Completion:{" "}
+                            <code>{MODEL_TOKEN_LIMITS.get(gpt4omini.id)?.max}</code>
                           </>
                         )}
                       </p>

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -79,6 +79,7 @@ export const MODEL_FRIENDLY_NAME: Map<string, string> = new Map(Object.entries({
   "gpt-4": "GPT-4",
   "gpt-4-32k": "GPT-4 32k",
   "gpt-4o": "GPT-4o",
+  "gpt-4o-mini": "GPT-4o mini",
   "gpt-3.5-turbo": "GPT-3.5 Turbo",
   "gpt-3.5-turbo-16k": "GPT-3.5 Turbo 16k"
 }));
@@ -104,6 +105,10 @@ export const MODEL_COSTS: Map<string, ModelCost> = new Map(Object.entries({
   'gpt-4o': {
     prompt: 0.005,
     complete: 0.015,
+  },
+  'gpt-4o-mini': {
+    prompt: 0.00015,
+    complete: 0.0006,
   },
   'gpt-3.5-turbo': {
     prompt: 0.0015,
@@ -135,6 +140,10 @@ export const MODEL_TOKEN_LIMITS: Map<string, ModelTokenLimits> = new Map(Object.
   'gpt-4o': {
     context: 128000,
     max: 4096,
+  },
+  'gpt-4o-mini': {
+    context: 128000,
+    max: 16384,
   },
   // TODO: Dec 11, 2023 gpt-35-turbo prompt will become 16385 (but complete will remain 4096)
   'gpt-3.5-turbo': {
@@ -271,7 +280,7 @@ export interface ExtensionSettings {
     generateCodeEnabled: boolean,
     apiBaseUrl: string,
     organization: string,
-    model: "gpt-4-turbo" | "gpt-4" | "gpt-4-32k" | "gpt-4o" | "gpt-3.5-turbo" | "gpt-3.5-turbo-16k",
+    model: "gpt-4-turbo" | "gpt-4" | "gpt-4-32k" | "gpt-4o" | "gpt-4o-mini" | "gpt-3.5-turbo" | "gpt-3.5-turbo-16k",
     maxTokens: number,
     temperature: number,
     top_p: number;


### PR DESCRIPTION
GPT-4o mini 🎉 

Reference:
- https://openai.com/api/pricing/
- https://platform.openai.com/docs/models/gpt-4o-mini
- https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `gpt-4o-mini` model, offering enhanced capabilities, affordability, and speed.
	- Updated model selection component to include and allow selection of the `gpt-4o-mini` model.

- **Improvements**
	- Enhanced model descriptions and cost information for better user understanding.
	- Updated model mappings to reflect new options, including token limits for the `gpt-4o-mini`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->