### PR TITLE
:art: Show max cost instead of max tokens in UI

### DIFF
--- a/src/renderer/components/QuestionInputField.tsx
+++ b/src/renderer/components/QuestionInputField.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Tooltip } from "react-tooltip";
-import { isInstructModel } from "../helpers";
+import { isInstructModel, useMaxCost } from "../helpers";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import { useMessenger } from "../sent-to-backend";
 import { RootState } from "../store";
@@ -40,6 +40,7 @@ export default ({
   const [showTokenBreakdown, setShowTokenBreakdown] = useState(false);
   const tokenCountRef = React.useRef<HTMLDivElement>(null);
   const [tokenCountLabel, setTokenCountLabel] = useState("0");
+  const maxCost = useMaxCost(currentConversation);
   // Animation on token count value change
   const [tokenCountAnimation, setTokenCountAnimation] = useState(false);
   const tokenCountAnimationTimer = useRef(null);
@@ -73,7 +74,7 @@ export default ({
     // Start a new timer
     tokenCountAnimationTimer.current = setTimeout(() => {
       setTokenCountAnimation(false);
-    }, 200) as any;
+    }, 500) as any;
 
     return () => clearTimeout(tokenCountAnimationTimer.current as any); // Cleanup on unmount
   }, [tokenCountLabel]);
@@ -385,7 +386,8 @@ export default ({
                 }
               }}
             >
-              {tokenCountLabel}
+              {"≤ $"}
+              {maxCost?.toFixed(2) ?? "???"}
               <TokenCountPopup
                 showTokenBreakdown={showTokenBreakdown}
                 currentConversation={currentConversation}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a cost management feature that displays the maximum cost associated with conversations.
	- Added a custom React hook for calculating maximum costs based on token counts and model rates.
  
- **Improvements**
	- Enhanced user interface by shifting focus from token counting to cost estimation.
	- Extended the animation duration for a more noticeable display of changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Before:
![image](https://github.com/user-attachments/assets/14d770b7-45ed-4ded-a6fe-fb59cea5b130)

After:
![image](https://github.com/user-attachments/assets/83f3161a-010b-4ae8-ba40-b88671f13dd9)

Closes #60