### PR TITLE
Update gpt-3.5-turbo pricing to the latest gpt-3.5-turbo-0125

### DIFF
--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -111,8 +111,8 @@ export const MODEL_COSTS: Map<string, ModelCost> = new Map(Object.entries({
     complete: 0.0006,
   },
   'gpt-3.5-turbo': {
-    prompt: 0.0015,
-    complete: 0.002,
+    prompt: 0.0005,
+    complete: 0.0015,
   },
   'gpt-3.5-turbo-16k': {
     prompt: 0.003,


### PR DESCRIPTION
The old one seemed to belong to gpt-3.5-turbo-0613 & gpt-3.5-turbo-0301

Reference:
- https://openai.com/api/pricing/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Reduced cost for the 'gpt-3.5-turbo' model: prompt cost decreased to $0.0005 and complete cost to $0.0015, making the model more economical for users.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->