### PR TITLE
Update model cost calculations for million tokens

### DIFF
--- a/src/renderer/components/ModelSelect.tsx
+++ b/src/renderer/components/ModelSelect.tsx
@@ -117,17 +117,17 @@ export default function ModelSelect({
             ? "FREE"
             : rate.prompt === undefined
             ? "varies"
-            : `$${(rate.prompt * 1000).toFixed(2)}/M`,
+            : `$${rate.prompt.toFixed(1)}/M`,
         completeText:
           rate.complete === 0
             ? "FREE"
             : rate.complete === undefined
             ? "varies"
-            : `$${(rate.complete * 1000).toFixed(2)}/M`,
+            : `$${(rate.complete * 1000).toFixed(1)}/M`,
         isFree: rate.prompt === 0 && rate.complete === 0,
         isExpensive:
-          (rate.prompt !== undefined && rate.prompt > 0.01) ||
-          (rate.complete !== undefined && rate.complete > 0.03),
+          (rate.prompt !== undefined && rate.prompt > 10) ||
+          (rate.complete !== undefined && rate.complete > 30),
       });
     });
 
@@ -801,7 +801,9 @@ export default function ModelSelect({
                 })()}
               {models &&
                 (() => {
-                  const gpt4omini = models.find((model) => model.id === "gpt-4o-mini");
+                  const gpt4omini = models.find(
+                    (model) => model.id === "gpt-4o-mini"
+                  );
 
                   if (!gpt4omini) {
                     return null;
@@ -822,11 +824,15 @@ export default function ModelSelect({
                       </span>
                       <p>
                         Quality: ⭐⭐⬜, Speed: ⚡⚡⚡, Cost: 💸⬜⬜, Context:{" "}
-                        <code>{MODEL_TOKEN_LIMITS.get(gpt4omini.id)?.context}</code>
+                        <code>
+                          {MODEL_TOKEN_LIMITS.get(gpt4omini.id)?.context}
+                        </code>
                         {MODEL_TOKEN_LIMITS.get(gpt4omini.id)?.max && (
                           <>
                             , Completion:{" "}
-                            <code>{MODEL_TOKEN_LIMITS.get(gpt4omini.id)?.max}</code>
+                            <code>
+                              {MODEL_TOKEN_LIMITS.get(gpt4omini.id)?.max}
+                            </code>
                           </>
                         )}
                       </p>

--- a/src/renderer/components/TokenCountPopup.tsx
+++ b/src/renderer/components/TokenCountPopup.tsx
@@ -60,12 +60,12 @@ export default function TokenCountPopup({
     const rates = getModelRates(currentConversation.model);
     let minCost =
       rates.prompt !== undefined
-        ? (minPromptTokens / 1000) * rates.prompt
+        ? (minPromptTokens / 1000000) * rates.prompt
         : undefined;
     // maxCost is based on current convo text at ratePrompt pricing + theoretical maximum response at rateComplete pricing
     let maxCost =
       minCost !== undefined && rates.complete !== undefined
-        ? minCost + (maxCompleteTokens / 1000) * rates.complete
+        ? minCost + (maxCompleteTokens / 1000000) * rates.complete
         : undefined;
 
     setMinPromptTokens(minPromptTokens);
@@ -112,7 +112,7 @@ export default function TokenCountPopup({
           {/* TODO: update translations */}
           {"tokens"}
           {" = "}
-          <code>${minCost?.toFixed(3) ?? "???"}</code>
+          <code>${minCost?.toFixed(2) ?? "???"}</code>
         </p>
         <p>
           <span className="block">
@@ -136,7 +136,7 @@ export default function TokenCountPopup({
           {/* TODO: update translations */}
           {"tokens"}
           {" = "}
-          <code>${maxCost?.toFixed(3) ?? "???"}</code>
+          <code>${maxCost?.toFixed(2) ?? "???"}</code>
         </p>
         <p className="italic">
           {t?.questionInputField?.tokenBreakdownRecommendation ??

--- a/src/renderer/helpers.tsx
+++ b/src/renderer/helpers.tsx
@@ -284,9 +284,9 @@ export function getModelRates(model: Model | undefined): ModelCosts {
 
   // For OpenRouter models, check if the model has cost data with it
   if (model.pricing) {
-    // Mutiply by 1,000 to convert from $ / 1 token to $ / 1,000 tokens
-    costs.prompt = parseFloat(model.pricing.prompt) * 1000;
-    costs.complete = parseFloat(model.pricing.completion) * 1000;
+    // Mutiply by 1,000,000 to convert from $ / 1 token to $ / 1 million tokens
+    costs.prompt = parseFloat(model.pricing.prompt) * 1000000;
+    costs.complete = parseFloat(model.pricing.completion) * 1000000;
     // If cost is < 0, set to undefined
     // -1 means "Pricing varied" (variable model)
     if (costs.prompt < 0) {
@@ -396,8 +396,8 @@ export function useMaxCost(conversation: Conversation) {
     const rates = getModelRates(conversation.model);
 
     if (rates.prompt !== undefined && rates.complete !== undefined) {
-      const minCost = (minPromptTokens / 1000) * rates.prompt;
-      setMaxCost(minCost + (maxCompleteTokens / 1000) * rates.complete);
+      const minCost = (minPromptTokens / 1000000) * rates.prompt;
+      setMaxCost(minCost + (maxCompleteTokens / 1000000) * rates.complete);
     } else {
       setMaxCost(undefined);
     }

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -89,34 +89,36 @@ interface ModelCost {
   prompt: number;
   complete: number;
 }
+
+// Token cost per 1 million tokens
 export const MODEL_COSTS: Map<string, ModelCost> = new Map(Object.entries({
   'gpt-4-turbo': {
-    prompt: 0.01,
-    complete: 0.03,
+    prompt: 10,
+    complete: 30,
   },
   'gpt-4': {
-    prompt: 0.03,
-    complete: 0.06,
+    prompt: 30,
+    complete: 60,
   },
   'gpt-4-32k': {
-    prompt: 0.06,
-    complete: 0.12,
+    prompt: 60,
+    complete: 120,
   },
   'gpt-4o': {
-    prompt: 0.005,
-    complete: 0.015,
+    prompt: 5,
+    complete: 15,
   },
   'gpt-4o-mini': {
-    prompt: 0.00015,
-    complete: 0.0006,
+    prompt: 0.15,
+    complete: 0.6,
   },
   'gpt-3.5-turbo': {
-    prompt: 0.0005,
-    complete: 0.0015,
+    prompt: 0.5,
+    complete: 1.5,
   },
   'gpt-3.5-turbo-16k': {
-    prompt: 0.003,
-    complete: 0.004,
+    prompt: 3,
+    complete: 4,
   },
 }));
 


### PR DESCRIPTION
Show $ / 1m tokens instead of $ / 1k tokens. This will make pricing more readable. At the moment, we actually do not show rates for OpenAI. But, in the future if we decide to, the groundwork is there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated pricing model with new cost structures for models, significantly increasing the displayed monetary values.
  - Adjusted the formatting of costs to enhance clarity, now displaying one or two decimal places where applicable.

- **Bug Fixes**
  - Corrected cost calculations to reflect a consistent unit of measurement, improving accuracy in displayed costs.

- **Documentation**
  - Enhanced cost-related information to better align with the new pricing strategy and display formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->