### PR TITLE
Update the context window and max output token of `gpt-3.5-turbo`

### DIFF
--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -147,9 +147,9 @@ export const MODEL_TOKEN_LIMITS: Map<string, ModelTokenLimits> = new Map(Object.
     context: 128000,
     max: 16384,
   },
-  // TODO: Dec 11, 2023 gpt-35-turbo prompt will become 16385 (but complete will remain 4096)
   'gpt-3.5-turbo': {
-    context: 4096,
+    context: 16385,
+    max: 4096,
   },
   'gpt-3.5-turbo-16k': {
     context: 16385,


### PR DESCRIPTION
I know we'll drop it at some point, but `gpt-3.5-turbo` currently points to `gpt-3.5-turbo-0125` with a 16385 tokens context window and a maximum of 4096 output tokens. It'll be good to make sure all the details are correct and not confusing to the users.

Reference:
- https://platform.openai.com/docs/models/gpt-3-5-turbo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased context limits for the 'gpt-3.5-turbo' model, allowing for improved performance and output quality in applications.

- **Documentation**
	- Removed outdated comments regarding future updates for model prompts, reflecting a focus on current capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->