### PR TITLE
Specify Node.js and Yarn versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "url": "https://github.com/vscode-reborn-ai/vscode-reborn-ai"
   },
   "engines": {
-    "vscode": "^1.70.0"
+    "vscode": "^1.70.0",
+    "node": ">=20"
   },
+  "packageManager": "yarn@1.22.19",
   "categories": [
     "Programming Languages",
     "Machine Learning",


### PR DESCRIPTION
Fixes #146

Add Node.js and Yarn versions to `package.json`.

* Add `engines` field to specify Node.js version ">=20".
* Add `packageManager` field to specify Yarn version "yarn@1.22.19".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vscode-reborn-ai/vscode-reborn-ai/pull/147?shareId=339c76c5-b9ca-4bed-ab45-c32a2b758180).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated system configuration to require Node.js version 20 or higher and Yarn version 1.22.19, ensuring improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->