### PR TITLE
Add GPT-4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [@Christopher-Hayes](github.com/Christopher-Hayes) - [@danyalaytekin](github.com/danyalaytekin) - [@flutterrausch](github.com/flutterrausch) - [@hakula139](github.com/hakula139) - [@lvii](github.com/lvii) - [@moritz-t-w](github.com/moritz-t-w) - [@nickv2002](github.com/nickv2002) - [@nossebro](github.com/nossebro) - [@PeterDaveHello](github.com/PeterDaveHello) - [@raphael2692](github.com/raphael2692) - [@rambalachandran](github.com/rambalachandran) - [@xmjiao](github.com/xmjiao) - [@wojtekcz](github.com/wojtekcz) - [@ZsgsDesign](github.com/ZsgsDesign) - [@zzy-life](github.com/zzy-life)
 
+## Next [next]
+
+- ✨ **Feature** - Added support for `gpt-4.1` when using OpenAI.
+- 📼 **Deprecated** - `gpt-4` is deprecated in favor of newer models.
+
 ## October 20, 2024 [v3.26.0]
 
 - ✨ **Feature** - Added support for `o1-preview` and `o1-mini` when using OpenAI.
@@ -142,7 +147,7 @@
 - 🎮 **QoL** - When opening code in a new text editor, VSCode should now automatically know how to syntax highlight it.
 - 🎮 **QoL** - Configuring "System message" is now an extension setting.
 
-[Not yet released]: https://github.com/vscode-reborn-ai/vscode-reborn-ai/compare/3.26.0...HEAD
+[next]: https://github.com/vscode-reborn-ai/vscode-reborn-ai/compare/3.26.0...HEAD
 [v3.26.0]: https://github.com/vscode-reborn-ai/vscode-reborn-ai/compare/3.25.0...3.26.0
 [v3.25.0]: https://github.com/vscode-reborn-ai/vscode-reborn-ai/compare/3.24.0...3.25.0
 [v3.24.0]: https://github.com/vscode-reborn-ai/vscode-reborn-ai/compare/3.23.2...3.24.0

--- a/package.json
+++ b/package.json
@@ -457,6 +457,7 @@
         "chatgpt.gpt3.model": {
           "type": "string",
           "enum": [
+            "gpt-4.5-preview",
             "gpt-4o",
             "gpt-4o-mini",
             "gpt-4-turbo",
@@ -468,6 +469,7 @@
           "markdownDescription": "OpenAI models to use for your prompts. [Documentation](https://platform.openai.com/docs/models/models). \n\n**If you face 400 Bad Request please make sure you are using the right model for your integration method.**",
           "order": 36,
           "enumItemLabels": [
+            "OpenAI GPT-4.5 Preview",
             "OpenAI GPT-4o",
             "OpenAI GPT-4o Mini",
             "OpenAI GPT-4 Turbo",
@@ -476,6 +478,7 @@
             "OpenAI GPT-3.5 Turbo"
           ],
           "markdownEnumDescriptions": [
+            "The latest high-intelligence model for complex tasks.",
             "High-intelligence flagship model for complex, multi-step tasks.",
             "Affordable and intelligent small model for fast, lightweight tasks",
             "The previous set of high-intelligence models. 3x cheaper than GPT-4. 16x longer inputs than GPT-4.",

--- a/package.json
+++ b/package.json
@@ -457,7 +457,7 @@
         "chatgpt.gpt3.model": {
           "type": "string",
           "enum": [
-            "gpt-4.5-preview",
+            "gpt-4.1",
             "gpt-4o",
             "gpt-4o-mini",
             "gpt-4-turbo",
@@ -465,11 +465,11 @@
             "gpt-4-32k",
             "gpt-3.5-turbo"
           ],
-          "default": "gpt-4o",
+          "default": "gpt-4.1",
           "markdownDescription": "OpenAI models to use for your prompts. [Documentation](https://platform.openai.com/docs/models/models). \n\n**If you face 400 Bad Request please make sure you are using the right model for your integration method.**",
           "order": 36,
           "enumItemLabels": [
-            "OpenAI GPT-4.5 Preview",
+            "OpenAI GPT-4.1",
             "OpenAI GPT-4o",
             "OpenAI GPT-4o Mini",
             "OpenAI GPT-4 Turbo",

--- a/src/renderer/components/ModelSelect.tsx
+++ b/src/renderer/components/ModelSelect.tsx
@@ -36,17 +36,17 @@ export interface RichModel extends Partial<Model> {
 }
 const modelsArray: RichModel[] = [
   {
-    id: "gpt-4.5-preview",
-    name: "gpt-4.5-preview",
+    id: "gpt-4.1",
+    name: "gpt-4.1",
     quality: "⭐⭐⭐",
-    speed: "⚡⬜⬜",
-    cost: "💸💸💸",
+    speed: "⚡⚡⬜",
+    cost: "💸💸⬜",
     recommended: true,
   },
   {
     id: "gpt-4-turbo",
     name: "gpt-4-turbo",
-    quality: "⭐⭐⬜",
+    quality: "⭐⬜⬜",
     speed: "⚡⚡⬜",
     cost: "💸💸⬜",
   },
@@ -63,7 +63,6 @@ const modelsArray: RichModel[] = [
     quality: "⭐⭐⭐",
     speed: "⚡⚡⚡",
     cost: "💸⬜⬜",
-    recommended: true,
   },
   {
     id: "gpt-4o-mini",

--- a/src/renderer/components/ModelSelect.tsx
+++ b/src/renderer/components/ModelSelect.tsx
@@ -36,6 +36,14 @@ export interface RichModel extends Partial<Model> {
 }
 const modelsArray: RichModel[] = [
   {
+    id: "gpt-4.5-preview",
+    name: "gpt-4.5-preview",
+    quality: "⭐⭐⭐",
+    speed: "⚡⬜⬜",
+    cost: "💸💸💸",
+    recommended: true,
+  },
+  {
     id: "gpt-4-turbo",
     name: "gpt-4-turbo",
     quality: "⭐⭐⬜",

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -375,7 +375,7 @@ export const DEFAULT_EXTENSION_SETTINGS: ExtensionSettings = {
     generateCodeEnabled: true,
     apiBaseUrl: "https://api.openai.com/v1",
     organization: "",
-    model: "gpt-4o",
+    model: "gpt-4.1",
     maxTokens: 4000,
     temperature: 1,
     top_p: 1

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -75,6 +75,7 @@ export interface Model {
 // Maps ID to a friendly name
 // Ref: https://platform.openai.com/docs/models
 export const MODEL_FRIENDLY_NAME: Map<string, string> = new Map(Object.entries({
+  "gpt-4.5-preview": "GPT-4.5 Preview",
   "gpt-4-turbo": "GPT-4 Turbo",
   "gpt-4": "GPT-4",
   "gpt-4-32k": "GPT-4 32k",
@@ -95,6 +96,10 @@ interface ModelCost {
 
 // Token cost per 1 million tokens
 export const MODEL_COSTS: Map<string, ModelCost> = new Map(Object.entries({
+  'gpt-4.5-preview': {
+    prompt: 75,
+    complete: 150,
+  },
   'gpt-4-turbo': {
     prompt: 10,
     complete: 30,
@@ -143,6 +148,10 @@ interface ModelTokenLimits {
   max?: number;
 }
 export const MODEL_TOKEN_LIMITS: Map<string, ModelTokenLimits> = new Map(Object.entries({
+  'gpt-4.5-preview': {
+    context: 128000,
+    max: 16384,
+  },
   'gpt-4-turbo': {
     context: 128000,
     max: 4096,
@@ -314,7 +323,7 @@ export interface ExtensionSettings {
     generateCodeEnabled: boolean,
     apiBaseUrl: string,
     organization: string,
-    model: "gpt-4-turbo" | "gpt-4" | "gpt-4-32k" | "gpt-4o" | "gpt-4o-mini" | "gpt-3.5-turbo" | "gpt-3.5-turbo-16k" | "o1" | "o1-preview" | "o1-mini",
+    model: "gpt-4.5-preview" | "gpt-4-turbo" | "gpt-4" | "gpt-4-32k" | "gpt-4o" | "gpt-4o-mini" | "gpt-3.5-turbo" | "gpt-3.5-turbo-16k" | "o1" | "o1-preview" | "o1-mini",
     maxTokens: number,
     temperature: number,
     top_p: number;

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -75,7 +75,7 @@ export interface Model {
 // Maps ID to a friendly name
 // Ref: https://platform.openai.com/docs/models
 export const MODEL_FRIENDLY_NAME: Map<string, string> = new Map(Object.entries({
-  "gpt-4.5-preview": "GPT-4.5 Preview",
+  "gpt-4.1": "GPT-4.1",
   "gpt-4-turbo": "GPT-4 Turbo",
   "gpt-4": "GPT-4",
   "gpt-4-32k": "GPT-4 32k",
@@ -96,9 +96,9 @@ interface ModelCost {
 
 // Token cost per 1 million tokens
 export const MODEL_COSTS: Map<string, ModelCost> = new Map(Object.entries({
-  'gpt-4.5-preview': {
-    prompt: 75,
-    complete: 150,
+  'gpt-4.1': {
+    prompt: 2,
+    complete: 8,
   },
   'gpt-4-turbo': {
     prompt: 10,
@@ -148,9 +148,9 @@ interface ModelTokenLimits {
   max?: number;
 }
 export const MODEL_TOKEN_LIMITS: Map<string, ModelTokenLimits> = new Map(Object.entries({
-  'gpt-4.5-preview': {
-    context: 128000,
-    max: 16384,
+  'gpt-4.1': {
+    context: 1047576,
+    max: 32768,
   },
   'gpt-4-turbo': {
     context: 128000,
@@ -323,7 +323,7 @@ export interface ExtensionSettings {
     generateCodeEnabled: boolean,
     apiBaseUrl: string,
     organization: string,
-    model: "gpt-4.5-preview" | "gpt-4-turbo" | "gpt-4" | "gpt-4-32k" | "gpt-4o" | "gpt-4o-mini" | "gpt-3.5-turbo" | "gpt-3.5-turbo-16k" | "o1" | "o1-preview" | "o1-mini",
+    model: "gpt-4.1" | "gpt-4-turbo" | "gpt-4" | "gpt-4-32k" | "gpt-4o" | "gpt-4o-mini" | "gpt-3.5-turbo" | "gpt-3.5-turbo-16k" | "o1" | "o1-preview" | "o1-mini",
     maxTokens: number,
     temperature: number,
     top_p: number;


### PR DESCRIPTION
### Description

:zap: Add `gpt-4.1` to the OpenAI provider list.

:fire: Removes `gpt-4` from the list.

This is a continuation of #152 

Fixes #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the OpenAI GPT-4.1 model, now available for selection and set as the default model.
  - Updated model selection interface to display GPT-4.1 with improved ratings and descriptive information.

- **Improvements**
  - Marked the previous GPT-4 model as deprecated in documentation.
  - Adjusted model quality ratings and recommendations for existing models in the selection interface.

- **Documentation**
  - Updated changelog format and entries to reflect new model support and naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->