### PR TITLE
Add OpenAI o3-mini model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ## Next [next]
 
-- ✨ **Feature** - Added support for `gpt-4.1`, and `o3-mini` when using OpenAI.
-- 📼 **Deprecated** - `gpt-4` is deprecated in favor of newer models.
+- ✨ **Feature** - Added support for `gpt-4.1` and `o3-mini` when using OpenAI. *Thanks @PeterDaveHello*
+- 📼 **Deprecated** - `gpt-4` and `o1-mini` are deprecated in favor of newer models.
 
 ## October 20, 2024 [v3.26.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Next [next]
 
-- ✨ **Feature** - Added support for `gpt-4.1` when using OpenAI.
+- ✨ **Feature** - Added support for `gpt-4.1`, and `o3-mini` when using OpenAI.
 - 📼 **Deprecated** - `gpt-4` is deprecated in favor of newer models.
 
 ## October 20, 2024 [v3.26.0]

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   ],
   "keywords": [
     "chatgpt",
-    "gpt4o",
-    "o1",
+    "gpt-4.1",
+    "o3-mini",
     "ai",
     "openai",
     "find bugs"

--- a/src/renderer/components/ModelSelect.tsx
+++ b/src/renderer/components/ModelSelect.tsx
@@ -90,15 +90,8 @@ const modelsArray: RichModel[] = [
     name: "o3-mini",
     quality: "⭐⭐⭐",
     speed: "⚡⚡⚡",
-    cost: "💸💸⬜"
-  },
-  {
-    id: "o1-mini",
-    name: "o1-mini",
-    quality: "⭐⭐⬜",
-    speed: "⚡⬜⬜",
     cost: "💸💸⬜",
-  }
+  },
 ];
 
 export default function ModelSelect({
@@ -185,14 +178,14 @@ export default function ModelSelect({
           rate.prompt === 0
             ? "FREE"
             : rate.prompt === undefined
-              ? "varies"
-              : `$${rate.prompt.toFixed(1)}/M`,
+            ? "varies"
+            : `$${rate.prompt.toFixed(1)}/M`,
         completeText:
           rate.complete === 0
             ? "FREE"
             : rate.complete === undefined
-              ? "varies"
-              : `$${rate.complete.toFixed(1)}/M`,
+            ? "varies"
+            : `$${rate.complete.toFixed(1)}/M`,
         isFree: rate.prompt === 0 && rate.complete === 0,
         isExpensive:
           (rate.prompt !== undefined && rate.prompt > 10) ||
@@ -290,10 +283,10 @@ export default function ModelSelect({
     const filteredModelList =
       query.length > 0
         ? modelList.filter(
-          (model) =>
-            model.id.toLowerCase().includes(query) ||
-            (model?.name && model.name.toLowerCase().includes(query))
-        )
+            (model) =>
+              model.id.toLowerCase().includes(query) ||
+              (model?.name && model.name.toLowerCase().includes(query))
+          )
         : modelList;
 
     setFilteredModels(sortList(sortBy, filteredModelList, !ascending));
@@ -377,8 +370,8 @@ export default function ModelSelect({
           {isCurrentModelAvailable
             ? currentModelFriendlyName
             : sync.receivedModels
-              ? t?.modelSelect?.noModelSelected ?? "No model selected"
-              : t?.modelSelect?.fetchingModels ?? "Fetching models.."}
+            ? t?.modelSelect?.noModelSelected ?? "No model selected"
+            : t?.modelSelect?.fetchingModels ?? "Fetching models.."}
         </button>
         <div
           className={`fixed mb-8 overflow-y-auto max-h-[calc(100%-10em)] max-w-[calc(100%-4em)] items-center more-menu border text-menu bg-menu border-menu shadow-xl text-xs rounded
@@ -498,8 +491,8 @@ export default function ModelSelect({
                         <div className="w-full flex justify-around gap-2 divide-dropdown text-2xs">
                           {computedModelDataMap.get(model.id)?.prompt ===
                             undefined &&
-                            (settings.gpt3.apiBaseUrl.includes("127.0.0.1") ||
-                              settings.gpt3.apiBaseUrl.includes("localhost")) ? (
+                          (settings.gpt3.apiBaseUrl.includes("127.0.0.1") ||
+                            settings.gpt3.apiBaseUrl.includes("localhost")) ? (
                             <>
                               {model.details?.family && (
                                 <span>{model.details.family}</span>

--- a/src/renderer/components/ModelSelect.tsx
+++ b/src/renderer/components/ModelSelect.tsx
@@ -86,12 +86,19 @@ const modelsArray: RichModel[] = [
     cost: "💸💸💸",
   },
   {
+    id: "o3-mini",
+    name: "o3-mini",
+    quality: "⭐⭐⭐",
+    speed: "⚡⚡⚡",
+    cost: "💸💸⬜"
+  },
+  {
     id: "o1-mini",
     name: "o1-mini",
-    quality: "⭐⭐⭐",
+    quality: "⭐⭐⬜",
     speed: "⚡⬜⬜",
     cost: "💸💸⬜",
-  },
+  }
 ];
 
 export default function ModelSelect({

--- a/src/renderer/components/ModelSelect.tsx
+++ b/src/renderer/components/ModelSelect.tsx
@@ -137,15 +137,9 @@ export default function ModelSelect({
   const convertMarkdownToComponent = useConvertMarkdownToComponent(vscode);
 
   const hasOpenAIModels = useMemo(() => {
-    // check if the model list has at least one of: gpt-4, gpt-4-turbo, gpt-4o, gpt-4o-mini, gpt-3.5-turbo
-    return models.some(
-      (model) =>
-        model.id === "gpt-4" ||
-        model.id === "gpt-4-turbo" ||
-        model.id === "gpt-4o" ||
-        model.id === "gpt-4o-mini" ||
-        model.id === "gpt-3.5-turbo"
-    );
+    // Check if the model list has at least one model from modelsArray
+    const openAIModelIds = modelsArray.map((model) => model.id);
+    return models.some((model) => openAIModelIds.includes(model.id));
   }, [models]);
 
   const isCurrentModelAvailable = useIsModelAvailable(
@@ -184,14 +178,14 @@ export default function ModelSelect({
           rate.prompt === 0
             ? "FREE"
             : rate.prompt === undefined
-            ? "varies"
-            : `$${rate.prompt.toFixed(1)}/M`,
+              ? "varies"
+              : `$${rate.prompt.toFixed(1)}/M`,
         completeText:
           rate.complete === 0
             ? "FREE"
             : rate.complete === undefined
-            ? "varies"
-            : `$${rate.complete.toFixed(1)}/M`,
+              ? "varies"
+              : `$${rate.complete.toFixed(1)}/M`,
         isFree: rate.prompt === 0 && rate.complete === 0,
         isExpensive:
           (rate.prompt !== undefined && rate.prompt > 10) ||
@@ -289,10 +283,10 @@ export default function ModelSelect({
     const filteredModelList =
       query.length > 0
         ? modelList.filter(
-            (model) =>
-              model.id.toLowerCase().includes(query) ||
-              (model?.name && model.name.toLowerCase().includes(query))
-          )
+          (model) =>
+            model.id.toLowerCase().includes(query) ||
+            (model?.name && model.name.toLowerCase().includes(query))
+        )
         : modelList;
 
     setFilteredModels(sortList(sortBy, filteredModelList, !ascending));
@@ -376,8 +370,8 @@ export default function ModelSelect({
           {isCurrentModelAvailable
             ? currentModelFriendlyName
             : sync.receivedModels
-            ? t?.modelSelect?.noModelSelected ?? "No model selected"
-            : t?.modelSelect?.fetchingModels ?? "Fetching models.."}
+              ? t?.modelSelect?.noModelSelected ?? "No model selected"
+              : t?.modelSelect?.fetchingModels ?? "Fetching models.."}
         </button>
         <div
           className={`fixed mb-8 overflow-y-auto max-h-[calc(100%-10em)] max-w-[calc(100%-4em)] items-center more-menu border text-menu bg-menu border-menu shadow-xl text-xs rounded
@@ -497,8 +491,8 @@ export default function ModelSelect({
                         <div className="w-full flex justify-around gap-2 divide-dropdown text-2xs">
                           {computedModelDataMap.get(model.id)?.prompt ===
                             undefined &&
-                          (settings.gpt3.apiBaseUrl.includes("127.0.0.1") ||
-                            settings.gpt3.apiBaseUrl.includes("localhost")) ? (
+                            (settings.gpt3.apiBaseUrl.includes("127.0.0.1") ||
+                              settings.gpt3.apiBaseUrl.includes("localhost")) ? (
                             <>
                               {model.details?.family && (
                                 <span>{model.details.family}</span>

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -86,6 +86,7 @@ export const MODEL_FRIENDLY_NAME: Map<string, string> = new Map(Object.entries({
   "o1": "o1",
   "o1-preview": "o1 Preview",
   "o1-mini": "o1 Mini",
+  "o3-mini": "o3 Mini",
 }));
 
 // source: https://openai.com/pricing
@@ -140,6 +141,10 @@ export const MODEL_COSTS: Map<string, ModelCost> = new Map(Object.entries({
     prompt: 3,
     complete: 12,
   },
+  'o3-mini': {
+    prompt: 1.10,
+    complete: 4.40,
+  },
 }));
 
 // source: https://platform.openai.com/docs/models
@@ -191,12 +196,16 @@ export const MODEL_TOKEN_LIMITS: Map<string, ModelTokenLimits> = new Map(Object.
     context: 128000,
     max: 65536,
   },
+  'o3-mini': {
+    context: 2000000,
+    max: 100000,
+  },
 }));
 
 // Reasoning models have specific constraints:
 // 1. System context messages are not allowed.
 // 2. Different max_tokens behavior - max_completion_tokens used instead.
-export const REASONING_MODELS = ['o1', 'o1-preview', 'o1-mini'];
+export const REASONING_MODELS = ['o1', 'o1-preview', 'o1-mini', 'o3-mini'];
 
 interface OpenAIMessage {
   role: Role;


### PR DESCRIPTION
The implementation introduces the OpenAI o3-mini model and refactors the model availability check for improved code clarity. Fixes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for the new OpenAI model "o3-mini" throughout the app, including model selection, cost display, and token limits.

- **Improvements**
	- Replaced "o1-mini" with "o3-mini" in the model selection menu, updating speed rating and availability.
	- Enhanced the logic for detecting OpenAI models in the selection interface to be more dynamic.

- **Documentation**
	- Updated changelog to reflect support for "gpt-4.1" and "o3-mini" and deprecation of "o1-mini".
	- Refreshed keywords in package metadata for better discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->